### PR TITLE
Change php-fpm php_admin* to php*

### DIFF
--- a/SOURCES/php-fpm-www.conf
+++ b/SOURCES/php-fpm-www.conf
@@ -216,7 +216,7 @@ slowlog = /var/log/php-fpm/www-slow.log
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 ;php_flag[display_errors] = off
-php_admin_value[error_log] = /var/log/php-fpm/www-error.log
-php_admin_value[session.save_path] = /var/lib/php/session
-php_admin_flag[log_errors] = on
+php_value[error_log] = /var/log/php-fpm/www-error.log
+php_value[session.save_path] = /var/lib/php/session
+php_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 128M


### PR DESCRIPTION
Forcing defaults of php_admin_value/flag makes applications that manage their ini settings fail.

For example Magento it is regular for it's local.xml to change the session save handler to memcache, however doing that and setting session.save_path fails

This change should be done against all PHP versions, however my workplace only uses this one (as uses a different PHP 3rd-party for later versions), so wont be testing the other versions.
